### PR TITLE
Firebase: support image with group/ticcle

### DIFF
--- a/src/firebase/Example.js
+++ b/src/firebase/Example.js
@@ -1,36 +1,47 @@
 /* This is example of using firebase function */
-import { createGroup, createTiccle } from "./Firestore";
+import { createGroup, createTiccle, uploadNewGroup, uploadNewTiccle, getGroupById, getTiccleById } from "./Firestore";
 import firestore from '@react-native-firebase/firestore';
 
-function testCreateGroup() {
+function testUploadNewGroup() {
     const groupName = 'new';
-    let newGroup = {
+    const newGroup = {
         lastModifiedTime: firestore.Timestamp.fromDate(new Date()),
         type: 5, // BOOK(0), BLOG(1), NEWS(2), WEB(3), SNS(4), ETC(5)
         title: groupName,
-        description: 'this is testing group',
-        mainImage: '' // URL in Storage
+        description: 'this is testing group'
     }
-    createGroup(groupName, newGroup)
+    const imageSource = '';
+    uploadNewGroup(groupName, newGroup, imageSource)
     .then((ref) => console.log(ref));
 }
 
-async function testCreateTiccle() {
+async function testUploadNewTiccle() {
     const ticcleName = 'newTiccle';
-    let newTiccle =  {
+    const newTiccle =  {
         lastModifiedTime: firestore.Timestamp.fromDate(new Date()),
         group: 'new',
         title: ticcleName,
         link: '', // URL of original content
-        imageList: null, // limit: 2 // { "ref": "message", }
         content: 'this is testing ticcle',
         tagList: ['테스트', '가자']
     }
-    const id = await createTiccle(ticcleName, newTiccle);
+    const images = [];
+    const id = await uploadNewTiccle(ticcleName, newTiccle, images);
     console.log(id);
 }
 
+async function testGetGroupById() {
+    const g = await getGroupById('new');
+    console.log(g.title, ":", g.description);
+}
+
+async function testGetTiccleById() {
+    const t = await getTiccleById('kKV5AfefvSppAOQWcSaa');
+    console.log(t.title, ":", t.content);
+}
 export {
-    testCreateGroup,
-    testCreateTiccle,
+    testUploadNewGroup,
+    testUploadNewTiccle,
+    testGetGroupById,
+    testGetTiccleById,
 }

--- a/src/firebase/Example.js
+++ b/src/firebase/Example.js
@@ -4,11 +4,11 @@ import {
     createTiccle, 
     uploadNewGroup,
     uploadNewTiccle, 
-    getAllGroup,
-    getGroupById, 
-    getTiccleById, 
+    findAllGroup,
+    findGroupById, 
+    findTiccleById, 
     checkIsExistingGroup,
-    getTiccleListByGroupId, } from "./Firestore";
+    findTiccleListByGroupId, } from "./Firestore";
 import firestore from '@react-native-firebase/firestore';
 
 function testUploadNewGroup() {
@@ -17,7 +17,8 @@ function testUploadNewGroup() {
         lastModifiedTime: firestore.Timestamp.fromDate(new Date()),
         type: 5, // BOOK(0), BLOG(1), NEWS(2), WEB(3), SNS(4), ETC(5)
         title: groupName,
-        description: 'this is testing group'
+        description: 'this is testing group',
+        bookmark: false,
     }
     const imageSource = '';
     uploadNewGroup(groupName, newGroup, imageSource)
@@ -25,32 +26,31 @@ function testUploadNewGroup() {
 }
 
 async function testUploadNewTiccle() {
-    const ticcleName = 'newTiccle';
     const newTiccle =  {
         lastModifiedTime: firestore.Timestamp.fromDate(new Date()),
         group: 'new',
-        title: ticcleName,
+        title: 'newTiccleName',
         link: '', // URL of original content
         content: 'this is testing ticcle',
         tagList: ['테스트', '가자']
     }
     const images = [];
-    const id = await uploadNewTiccle(ticcleName, newTiccle, images);
+    const id = await uploadNewTiccle(newTiccle, images);
     console.log(id);
 }
 
-async function testGetAllGroups(){
-    const groups = await getAllGroup();
+async function testFindAllGroups(){
+    const groups = await findAllGroup();
     console.log(groups);
 }
 
-async function testGetGroupById() {
-    const g = await getGroupById('new');
+async function testFindGroupById() {
+    const g = await findGroupById('new');
     console.log(g.title, ":", g.description, g.lastModifiedTime.toDate());
 }
 
-async function testGetTiccleById() {
-    const t = await getTiccleById('kKV5AfefvSppAOQWcSaa');
+async function testFindTiccleById() {
+    const t = await findTiccleById('kKV5AfefvSppAOQWcSaa');
     console.log(t.title, ":", t.content, t.lastModifiedTime.toDate());
 }
 
@@ -59,17 +59,17 @@ async function testCheckIsExistingGroup() {
     console.log("exists: ", isExisting);
 }
 
-async function testGetTiccleListByGroupId() {
-    const ticcleList = await getTiccleListByGroupId('new');
+async function testFindTiccleListByGroupId() {
+    const ticcleList = await findTiccleListByGroupId('new');
     console.log(ticcleList);
 }
 
 export {
     testUploadNewGroup,
     testUploadNewTiccle,
-    testGetAllGroups,
-    testGetGroupById,
-    testGetTiccleById,
+    testFindAllGroups,
+    testFindGroupById,
+    testFindTiccleById,
     testCheckIsExistingGroup,
-    testGetTiccleListByGroupId,
+    testFindTiccleListByGroupId,
 }

--- a/src/firebase/Example.js
+++ b/src/firebase/Example.js
@@ -6,9 +6,12 @@ import {
     uploadNewTiccle, 
     findAllGroup,
     findGroupById, 
+    findGroupsIncludeImage,
     findTiccleById, 
     checkIsExistingGroup,
-    findTiccleListByGroupId, } from "./Firestore";
+    findTiccleListByGroupId, 
+    getImagesOfTiccle, 
+} from "./Firestore";
 import firestore from '@react-native-firebase/firestore';
 
 function testUploadNewGroup() {
@@ -46,7 +49,14 @@ async function testFindAllGroups(){
 
 async function testFindGroupById() {
     const g = await findGroupById('new');
-    console.log(g.title, ":", g.description, g.lastModifiedTime.toDate());
+    console.log(g.title, ":", g.description, g.lastModifiedTime);
+}
+
+async function testFindGroupsIncludeImage() {
+    const groupList = await findGroupsIncludeImage(10);
+    groupList.forEach(g => {
+        console.log(g.title, ":", g.description, g.lastModifiedTime);
+    })
 }
 
 async function testFindTiccleById() {
@@ -64,12 +74,18 @@ async function testFindTiccleListByGroupId() {
     console.log(ticcleList);
 }
 
+async function testGetImagesOfTiccle() {
+    // not yet
+}
+
 export {
     testUploadNewGroup,
     testUploadNewTiccle,
     testFindAllGroups,
+    testFindGroupsIncludeImage,
     testFindGroupById,
     testFindTiccleById,
     testCheckIsExistingGroup,
     testFindTiccleListByGroupId,
+    testGetImagesOfTiccle,
 }

--- a/src/firebase/Example.js
+++ b/src/firebase/Example.js
@@ -1,5 +1,14 @@
 /* This is example of using firebase function */
-import { createGroup, createTiccle, uploadNewGroup, uploadNewTiccle, getGroupById, getTiccleById } from "./Firestore";
+import {
+    createGroup, 
+    createTiccle, 
+    uploadNewGroup,
+    uploadNewTiccle, 
+    getAllGroup,
+    getGroupById, 
+    getTiccleById, 
+    checkIsExistingGroup,
+    getTiccleListByGroupId, } from "./Firestore";
 import firestore from '@react-native-firebase/firestore';
 
 function testUploadNewGroup() {
@@ -30,18 +39,37 @@ async function testUploadNewTiccle() {
     console.log(id);
 }
 
+async function testGetAllGroups(){
+    const groups = await getAllGroup();
+    console.log(groups);
+}
+
 async function testGetGroupById() {
     const g = await getGroupById('new');
-    console.log(g.title, ":", g.description);
+    console.log(g.title, ":", g.description, g.lastModifiedTime.toDate());
 }
 
 async function testGetTiccleById() {
     const t = await getTiccleById('kKV5AfefvSppAOQWcSaa');
-    console.log(t.title, ":", t.content);
+    console.log(t.title, ":", t.content, t.lastModifiedTime.toDate());
 }
+
+async function testCheckIsExistingGroup() {
+    const isExisting = await checkIsExistingGroup('new');
+    console.log("exists: ", isExisting);
+}
+
+async function testGetTiccleListByGroupId() {
+    const ticcleList = await getTiccleListByGroupId('new');
+    console.log(ticcleList);
+}
+
 export {
     testUploadNewGroup,
     testUploadNewTiccle,
+    testGetAllGroups,
     testGetGroupById,
     testGetTiccleById,
+    testCheckIsExistingGroup,
+    testGetTiccleListByGroupId,
 }

--- a/src/firebase/Firestore.js
+++ b/src/firebase/Firestore.js
@@ -13,19 +13,19 @@ const userDoc = firestore().collection('RTiccle').doc(user.uid);
  */
 async function createGroup(groupName, newGroup) {
     const ref = userDoc.collection("Group").doc(groupName);
+    console.log(newGroup);
     await ref.set(newGroup);
     return ref.id;
 }
 
 /**
- * @param {string} ticcleName 
  * @param {*} newTiccle
  * @returns Ticcle Id
  */
-async function createTiccle(ticcleName, newTiccle) {
+async function createTiccle(newTiccle) {
     const ref = userDoc.collection("Ticcle"); // using auto id
-    await ref.add(newTiccle);
-    return ref.id;
+    const ticcleRef = await ref.add(newTiccle);
+    return ticcleRef.id;
 }
 
 /**
@@ -37,6 +37,7 @@ async function createTiccle(ticcleName, newTiccle) {
         type: integer, // BOOK(0), BLOG(1), NEWS(2), WEB(3), SNS(4), ETC(5)
         title: String,
         description: String,
+        bookmark: Boolean, // true if bookmarked
     }
  * @param {*} mainImageSource: main image source of group
  */
@@ -51,7 +52,6 @@ function uploadNewGroup(newGroupName, group, mainImageSource) {
 
 /**
  * Upload new ticcle to firestore (upload image and group)
- * @param {string} newTiccleName 
  * @param {*} ticcle: ticcle info 
  *  * {
         lastModifiedTime: TimeStamp,
@@ -63,7 +63,7 @@ function uploadNewGroup(newGroupName, group, mainImageSource) {
     }
  * @param {Array} images: image source array - LIMIT 2
  */
-function uploadNewTiccle(newTiccleName, ticcle, images) {
+function uploadNewTiccle(ticcle, images) {
     // upload images first
     var imageArr = [];
     if(images !== undefined) {
@@ -73,18 +73,16 @@ function uploadNewTiccle(newTiccleName, ticcle, images) {
             uploadImageToStorage(imageName, image);
         })
     }
-    console.log(ticcle);
-    console.log({...ticcle, images: imageArr});
 
     // upload ticcle info
-    return createTiccle(newTiccleName, {...ticcle, images: imageArr});
+    return createTiccle({...ticcle, images: imageArr});
 }
 
 /**
  * Get All Group of User
  * @returns QuerySnapshot
  */
-async function getAllGroup() {
+async function findAllGroup() {
     const querySnapshot = await userDoc.collection("Group").get();
     var groups = [];
     querySnapshot.forEach(snapshot => {
@@ -114,7 +112,7 @@ async function getAllGroup() {
  * @param {*} groupId 
  * @returns DocumentSnapshot(of Group doc) if exist, else null
  */
-async function getGroupById(groupId) {
+async function findGroupById(groupId) {
     const group = await userDoc.collection("Group").doc(groupId).get();
     if (group.exists) return group.data();
     else return null;
@@ -125,7 +123,7 @@ async function getGroupById(groupId) {
  * @param {string} groupId 
  * @returns Ticcle List
  */
-async function getTiccleListByGroupId(groupId) {
+async function findTiccleListByGroupId(groupId) {
     const query = userDoc.collection("Ticcle")
     .where("group", "==", groupId);
     const querySnapshot = await query.get();
@@ -144,7 +142,7 @@ async function getTiccleListByGroupId(groupId) {
  * @param {*} ticcleId 
  * @returns DocumentSnapshot(of Ticcle doc) if exist, else null
  */
-async function getTiccleById(ticcleId) {
+async function findTiccleById(ticcleId) {
     const ticcle = await userDoc.collection("Ticcle").doc(ticcleId).get()
     if(ticcle.exists) return ticcle.data();
     else return null;
@@ -155,9 +153,9 @@ export {
     createTiccle,
     uploadNewGroup,
     uploadNewTiccle,
-    getAllGroup,
+    findAllGroup,
     checkIsExistingGroup,
-    getTiccleListByGroupId,
-    getGroupById,
-    getTiccleById,
+    findTiccleListByGroupId,
+    findGroupById,
+    findTiccleById,
 }

--- a/src/firebase/Firestore.js
+++ b/src/firebase/Firestore.js
@@ -85,11 +85,28 @@ function uploadNewTiccle(newTiccleName, ticcle, images) {
  * @returns QuerySnapshot
  */
 async function getAllGroup() {
-    const groups = await userDoc.collection("Group").get();
-    // groups.forEach(snapshot => {
-    //     console.log(snapshot.id, snapshot.data());
-    // })
+    const querySnapshot = await userDoc.collection("Group").get();
+    var groups = [];
+    querySnapshot.forEach(snapshot => {
+        const id = snapshot.id;
+        const group = {...snapshot.data(), id}
+        groups = [...groups, group];
+    })
     return groups;
+}
+
+/**
+ * check whether a group name exists or not
+ * @param {string} groupName 
+ * @returns true is existing group
+ */
+ async function checkIsExistingGroup(groupName) {
+    const querySnapshot = await userDoc.collection("Group").get();
+    var found = false;
+    querySnapshot.forEach(snapshot => {
+        if(snapshot.id == groupName) found = true;
+    })
+    return found;
 }
 
 /**
@@ -99,8 +116,27 @@ async function getAllGroup() {
  */
 async function getGroupById(groupId) {
     const group = await userDoc.collection("Group").doc(groupId).get();
-    if (group.exists) return group._data;
+    if (group.exists) return group.data();
     else return null;
+}
+
+/**
+ * Get ticcle list by group id
+ * @param {string} groupId 
+ * @returns Ticcle List
+ */
+async function getTiccleListByGroupId(groupId) {
+    const query = userDoc.collection("Ticcle")
+    .where("group", "==", groupId);
+    const querySnapshot = await query.get();
+
+    var ticcleList = [];
+    querySnapshot.forEach(snapshot => {
+        const id = snapshot.id;
+        const ticcle = {...snapshot.data(), id}
+        ticcleList = [...ticcleList, ticcle];
+    });
+    return ticcleList;
 }
 
 /**
@@ -110,7 +146,7 @@ async function getGroupById(groupId) {
  */
 async function getTiccleById(ticcleId) {
     const ticcle = await userDoc.collection("Ticcle").doc(ticcleId).get()
-    if(ticcle.exists) return ticcle._data;
+    if(ticcle.exists) return ticcle.data();
     else return null;
 }
 
@@ -120,6 +156,8 @@ export {
     uploadNewGroup,
     uploadNewTiccle,
     getAllGroup,
+    checkIsExistingGroup,
+    getTiccleListByGroupId,
     getGroupById,
     getTiccleById,
 }

--- a/src/firebase/Storage.js
+++ b/src/firebase/Storage.js
@@ -32,4 +32,19 @@ async function uploadImageToStorage(imageName, source, isTiccle) {
     });
 }
 
-export default uploadImageToStorage;
+/**
+ * Get download URL by imageName
+ * @param {string} imageName: image name 
+ * @param {boolean} isTiccle: image type (ture if ticcle image, false if group image)
+ * @returns URL
+ */
+async function getDownloadURLByName(imageName, isTiccle) {
+    const user = getCurrentUser();
+    const userRef = isTiccle ? storage().ref("ticcle").child(user.uid) : storage().ref("group").child(user.uid);
+    return await storage().userRef.child(imageName).getDownloadURL();
+}
+
+export {
+    uploadImageToStorage,
+    getDownloadURLByName,
+}

--- a/src/navigation/TabNav.js
+++ b/src/navigation/TabNav.js
@@ -7,7 +7,7 @@ import { type } from '../theme/fonts';
 import metrics from '../theme/metrices';
 
 import GroupCreate from '../containers/group/create/GroupCreate';
-import MyPage from '../containers/user';
+import MyPage from '../containers/user/MyPage';
 import TiccleCreate from '../containers/ticcle/create';
 
 import HomeStackNavigatior from './stack/HomeStackNavigator';


### PR DESCRIPTION
## 개요
- firebase 에서의 작업 추가

## 상세내용
현재 화면 구현에 따른 필요한 서비스 추가
- 새로 생성 시, image 업로드 후 Group/Ticcle 생성
- Group 이름 중복 체크
- 특정 Group 내의 Ticcle List 받아오기 (by Group ID)
- Group 의 main image 의 url 을 찾아서 Group List 반환 (단순 group 들 정보 받아오는 것과 다름)
- Ticcle 의 image name (array) 로 image url 찾아서 반환

## 리뷰어가 확인할 사항

## 기타
- 관련해서 문서화 작업 예정
- 현재는 Example 을 테스트 용도로 사용하는데, 아예 테스트 코드를 작성할 예정