### PR TITLE
Fix/handle data

### DIFF
--- a/src/containers/group/detail/GroupDetail.js
+++ b/src/containers/group/detail/GroupDetail.js
@@ -14,8 +14,6 @@ const GroupDetail = ({route, navigation}) => {
     const [list, setList] = useState([]);
     const [group, setGroup] = useState(route.params?.groupData);
     useEffect(() => {
-        console.log('\n\n\ngroup detail=================');
-        console.log(group);
         // get/set ticcle List
         getTiccleListByGId(route.params.groupData.id).then(() => {
             setList(ticcleList);

--- a/src/containers/group/detail/GroupDetail.js
+++ b/src/containers/group/detail/GroupDetail.js
@@ -1,8 +1,8 @@
 import React, {useState, useEffect} from 'react';
 import {Image, TouchableOpacity, StyleSheet} from 'react-native';
-import GroupInfo from './components/GroupInfo';
+import GroupInfo from './components/groupInfo';
 import SearchBar from '../../common/SearchBar';
-import ZeroTiccle from './components/ZeroTiccle';
+import ZeroTiccle from './components/zeroTiccle';
 import GroupDetailTiccleList from './components/GroupDetailTiccleList';
 import useTiccleChanged from '../../../context/hook/useTiccleChanged';
 import {getTiccleListByGId} from '../../../model/TiccleModel';

--- a/src/containers/group/detail/components/groupInfo.js
+++ b/src/containers/group/detail/components/groupInfo.js
@@ -22,11 +22,9 @@ const GroupInfo = ({groupData, navigation}) => {
         if (isBookmark == true) {
             setIsBookmark(false);
             doUpdateGroup(groupData.id, {bookmark: false}, false);
-            console.log(groupData);
         } else {
             setIsBookmark(true);
             doUpdateGroup(groupData.id, {bookmark: true}, false);
-            console.log(groupData);
         }
         setIsGroupChanged(!isGroupChanged); // notify groupData changed
     }

--- a/src/containers/group/update/components/GroupUpdateSaveButton.js
+++ b/src/containers/group/update/components/GroupUpdateSaveButton.js
@@ -7,10 +7,10 @@ import useGroupChanged from '../../../../context/hook/useGroupChanged';
 import {doUpdateGroup} from '../../../../model/GroupModel';
 
 const GroupUpdateSaveButton = ({navigation, initialData}) => {
-    const {groupUpdate, initialGroupUpdate} = useGroupUpdate();
+    const {groupUpdate, initialGroupUpdate, setGroupUpdateImage} = useGroupUpdate();
     const {isGroupChanged, setIsGroupChanged} = useGroupChanged();
 
-    const groupUpdateFirebase = () => {
+    const groupUpdateFirebase = async () => {
         let newInfo = [];
         let image = '';
         if (groupUpdate.title != initialData.title) newInfo.title = groupUpdate.title;
@@ -22,13 +22,12 @@ const GroupUpdateSaveButton = ({navigation, initialData}) => {
             if (image != '') {
                 const oldImageName = initialData.mainImage;
                 const newImageSource = image;
-                doUpdateGroup(groupId, newInfo, true, oldImageName, newImageSource);
+                const newImageUrl = await doUpdateGroup(groupId, newInfo, true, oldImageName, newImageSource);
+                setGroupUpdateImage(newImageUrl);
             } else {
                 doUpdateGroup(groupId, newInfo, false);
             }
             setIsGroupChanged(!isGroupChanged); // notify groupData changed
-            console.log('Group update save========================');
-            console.log(isGroupChanged);
             navigation.navigate({
                 name: 'GroupDetail',
                 params: {

--- a/src/containers/home/Home.js
+++ b/src/containers/home/Home.js
@@ -14,7 +14,6 @@ const Home = ({navigation}) => {
         (async () => {
             await getAllGroupIncludeImages(); // init group data
             setIsGroupChanged(!isGroupChanged);
-            console.log('================Home');
         })();
     }, []);
 

--- a/src/containers/home/components/BookmarkGroupList.js
+++ b/src/containers/home/components/BookmarkGroupList.js
@@ -1,7 +1,7 @@
 import React, {useEffect, useState} from 'react';
 import {Text, View, ScrollView, StyleSheet} from 'react-native';
 import {type} from '../../../theme/fonts';
-import {groupList} from '../../../model/GroupModel';
+import {getBookmarkedGroupList} from '../../../model/GroupModel';
 import useGroupChanged from '../../../context/hook/useGroupChanged';
 import BookmarkGroup from './BookmarkGroup';
 
@@ -11,8 +11,7 @@ const BookmarkGroupList = () => {
     const {isGroupChanged} = useGroupChanged();
     let bookmarkedList = '';
     useEffect(() => {
-        bookmarkedList = groupList.filter(obj => obj.bookmark == true); // 업데이트된 텍스트(title 등)는 바로 반영하지만, 이미지 업데이트 속도 때문에 예전 이미지 정보로 가져오는지 업데이트된 이미지는 바로 반영 x
-        // bookmarkedList = groupList; groupList로 직접 가져오면 업데이트된 텍스트 뿐만 아니라 이미지까지 바로 반영해서 보여줌.(NewTiccleGroupList가 이 경우) model에 bookmarkedGroupList를 만드는 건 어떨지...
+        bookmarkedList = getBookmarkedGroupList();
         if (bookmarkedList.length == 0) {
             setExistBookmark(false);
         } else {

--- a/src/containers/home/components/BookmarkGroupList.js
+++ b/src/containers/home/components/BookmarkGroupList.js
@@ -1,7 +1,7 @@
 import React, {useEffect, useState} from 'react';
 import {Text, View, ScrollView, StyleSheet} from 'react-native';
 import {type} from '../../../theme/fonts';
-import {getBookmarkedGroupList} from '../../../model/GroupModel';
+import {groupList} from '../../../model/GroupModel';
 import useGroupChanged from '../../../context/hook/useGroupChanged';
 import BookmarkGroup from './BookmarkGroup';
 
@@ -9,9 +9,8 @@ const BookmarkGroupList = () => {
     const [existBookmark, setExistBookmark] = useState(false);
     const [data, setData] = useState([]);
     const {isGroupChanged} = useGroupChanged();
-    let bookmarkedList = '';
     useEffect(() => {
-        bookmarkedList = getBookmarkedGroupList();
+        let bookmarkedList = groupList.filter(obj => obj.bookmark == true);
         if (bookmarkedList.length == 0) {
             setExistBookmark(false);
         } else {

--- a/src/containers/ticcle/create/components/group/GroupCreateModal.js
+++ b/src/containers/ticcle/create/components/group/GroupCreateModal.js
@@ -6,7 +6,6 @@ import GroupCreateModalTitle from "./create/GroupCreateModalTitle";
 import GroupCreateModalTextInput from "./create/GroupCreateModalTextInput";
 import GroupCreateModalGroupType from "./create/GroupCreateModalGroupType";
 import GroupCreateModalButton from "./create/GroupCreateModalButton";
-import { FBDate } from "../../../../../service/CommonService";
 import { uploadNewGroup } from "../../../../../service/GroupService";
 
 const GroupCreateModal = ({isModalVisible, setModalVisible}) => {
@@ -21,7 +20,6 @@ const GroupCreateModal = ({isModalVisible, setModalVisible}) => {
     const fastUploadNewGroup = () => {
         const groupName = groupTitle
         const newGroup = {
-            lastModifiedTime: FBDate(),
             type: type,
             title: groupName,
             description: '',

--- a/src/context/hook/UseTiccleCreate.js
+++ b/src/context/hook/UseTiccleCreate.js
@@ -4,12 +4,12 @@ import AppContext from '../AppContext';
 const UseTiccleCreate = () => {
     const {ticcle, setTiccleGroup, setTiccleTitle, setTiccleLink,
         setTiccleTagList, deleteTiccleTagList, setTiccleContent, setTiccleImages, deleteTiccleImage,
-        setTiccleDate, initialTiccle, 
+        initialTiccle, 
     } = useContext(AppContext);
 
     return {ticcle, setTiccleGroup, setTiccleTitle, setTiccleLink,
         setTiccleTagList, deleteTiccleTagList, setTiccleContent, setTiccleImages, deleteTiccleImage,
-        setTiccleDate, initialTiccle
+        initialTiccle
     };
 }
 

--- a/src/context/provider/AppProvider.js
+++ b/src/context/provider/AppProvider.js
@@ -5,7 +5,6 @@ import {FBDate} from '../../service/CommonService';
 const AppProvider = ({children}) => {
     //Ticcle
     const [ticcle, setTiccle] = useState({
-        lastModifiedTime: '',
         group: '',
         title: '',
         link: '',
@@ -28,14 +27,6 @@ const AppProvider = ({children}) => {
         setTiccle(state => {
             return {...state, link: text};
         });
-    };
-    const setTiccleDate = () => {
-        const today = FBDate();
-        setTiccle(state => {
-            return {...state, lastModifiedTime: today};
-        });
-
-        console.log(ticcle);
     };
     const setTiccleTagList = tag => {
         if (tag == '') return; // 비어있을 경우
@@ -74,7 +65,6 @@ const AppProvider = ({children}) => {
     };
     const initialTiccle = () => {
         setTiccle({
-            lastModifiedTime: '',
             group: '',
             title: '',
             link: '',
@@ -86,7 +76,6 @@ const AppProvider = ({children}) => {
 
     // Group
     const [groupCreate, setGroupCreate] = useState({
-        lastModifiedTime: '',
         title: '',
         description: '',
         bookmark: false,
@@ -94,7 +83,6 @@ const AppProvider = ({children}) => {
     });
     const initialGroupCreate = () => {
         setGroupCreate({
-            lastModifiedTime: '',
             title: '',
             description: '',
             bookmark: false,
@@ -167,7 +155,6 @@ const AppProvider = ({children}) => {
                 setTiccleImages,
                 initialTiccle,
                 deleteTiccleImage,
-                setTiccleDate,
                 groupCreate,
                 setGroupCreate,
                 initialGroupCreate,

--- a/src/model/GroupModel.js
+++ b/src/model/GroupModel.js
@@ -75,7 +75,10 @@ async function doUpdateGroup(groupId, newInfo, isIncludingImage, oldImageName, n
 
     // to local data
     const oldInfo = groupList.find(g => g.id == groupId);
-    setGroupListAtOne(groupId, {...oldInfo, ...info, imageUrl: imageUrl});
+    var newInfo = {};
+    if (imageUrl == '') newInfo = {...oldInfo, ...info}
+    else newInfo = {...oldInfo, ...info, imageUrl: imageUrl}
+    setGroupListAtOne(groupId, newInfo);
 }
 
 /**

--- a/src/model/GroupModel.js
+++ b/src/model/GroupModel.js
@@ -5,6 +5,21 @@ import {
     deleteGroup,
     findAllGroupIncludeImage } from '../service/GroupService';
 
+/*
+ * Group data
+    {
+        id: string, // random, unique id
+        title: string,
+        description: string,
+        bookmark: Boolean, // true if bookmarked
+        mainImage: string, // path in storage
+        imageUrl: string, // downloadUrl of image
+        ticcleNum: integer, 
+        latestTiccleTitle: string, 
+        lastModifiedTime: number // this treated like 'createdTime' (NOT UPDATE after create)
+    }
+*/
+
 // group list
 var groupList = [];
 const setGroupListAtOne = (targetGId, groupData) => {

--- a/src/model/GroupModel.js
+++ b/src/model/GroupModel.js
@@ -1,8 +1,8 @@
 import {
-        uploadNewGroup,
-        updateGroupInfo, updateGroupImage,
-        deleteGroup,
-        findAllGroupIncludeImage } from '../service/GroupService';
+    uploadNewGroup,
+    updateGroupInfo, updateGroupImage,
+    deleteGroup,
+    findAllGroupIncludeImage } from '../service/GroupService';
 
 // group list
 var groupList = [];
@@ -26,14 +26,6 @@ async function getAllGroupIncludeImages() {
 }
 
 /**
- * Get bookmarked group list
- * @returns {Array} bookmarked group list
- */
-async function getBookmarkedGroupList() {
-    return groupList.filter(obj => obj.bookmark == true);
-}
-
-/**
  * Upload new group and add to groupList
  * @param {*} groupData: group info
  * *  {
@@ -45,14 +37,10 @@ async function getBookmarkedGroupList() {
  */
 async function doCreateGroup(groupData, mainImageSource) {
     // to server
-    const newGroupInfo = await uploadNewGroup( groupData, mainImageSource );
+    var newGroupInfo = uploadNewGroup(groupData, mainImageSource);
 
     // to local data
-    // groupList = ([...groupList, newGroupInfo])
-    // console.log(groupList);
-    groupList = [...groupList, newGroupInfo];
-    console.log('\n\ndoCreateGroup========');
-    console.log(newGroupInfo);
+    groupList = [await newGroupInfo, ...groupList];
     return new Promise(resolve => {
         resolve(newGroupInfo);
     });
@@ -67,27 +55,27 @@ async function doCreateGroup(groupData, mainImageSource) {
         title: String,
         description: String,
         bookmark: Boolean, // true if bookmarked
-}
-* @param {*} isIncludingImage if update image, ture. else false(: no need to consider below parameters)
-* @param {*} oldImageName old image name
-* @param {*} newImageSource new image source
-*/
+ *    }
+ * @param {*} isIncludingImage if update image, ture. else false(: no need to consider below parameters)
+ * @param {*} oldImageName old image name
+ * @param {*} newImageSource new image source
+ */
 async function doUpdateGroup(groupId, newInfo, isIncludingImage, oldImageName, newImageSource) {
     var info = {...newInfo};
+    var imageUrl = '';
 
     // to server
     if (isIncludingImage) {
         const newImageInfo = await updateGroupImage(oldImageName, newImageSource);
         const [downloadUrl, newImageName] = newImageInfo;
-        info = {...info, imageUrl: downloadUrl, mainImage: newImageName};
-        console.log('\n\ndoUpdate image========');
-        console.log(newImageInfo);
+        imageUrl = downloadUrl;
+        info = {...info, mainImage: newImageName};
     }
     updateGroupInfo(groupId, info);
 
     // to local data
     const oldInfo = groupList.find(g => g.id == groupId);
-    setGroupListAtOne(groupId, {...oldInfo, ...info});
+    setGroupListAtOne(groupId, {...oldInfo, ...info, imageUrl: imageUrl});
 }
 
 /**
@@ -115,8 +103,7 @@ function checkIsExistingGroup(groupTitle) {
 
 export {
     groupList, 
-    getAllGroupIncludeImages, 
-    getBookmarkedGroupList,
+    getAllGroupIncludeImages,
     doCreateGroup, 
     doUpdateGroup, 
     doDeleteGroup, 

--- a/src/model/GroupModel.js
+++ b/src/model/GroupModel.js
@@ -16,6 +16,10 @@ const deleteOneGroupOfList = targetGId => {
     groupList.splice(idx, 1);
 };
 
+// limit
+const limitGroupNum = 20;
+const limitTiccleNum = 100;
+
 /**
  * Get all group list and set groupList
  */
@@ -108,11 +112,55 @@ function checkIsExistingGroup(groupTitle) {
     else return true;
 }
 
+/**
+ * Get user's group nubmer
+ * @returns {integer} total number of groups
+ */
+ function getTotalGroupNum() {
+    return groupList.length;
+}
+
+/**
+ * Check user has more groups than limit
+ * @returns {boolean}
+ */
+function checkIsFullGroupNum() {
+    if (getTotalGroupNum() >= limitGroupNum) return true;
+    else return false;  
+}
+
+/**
+ * Get user's ticcle nubmer
+ * @returns {integer} total number of ticcles
+ */
+function getTotalTiccleNum() {
+    var totalNum = 0;
+    groupList.forEach((group) => {
+        totalNum = totalNum + group.ticcleNum;
+    })
+    return totalNum;
+}
+
+/**
+ * Check user has more ticcles than limit
+ * @returns {boolean}
+ */
+function checkIsFullTiccleNum() {
+    if (getTotalTiccleNum() >= limitTiccleNum) return true;
+    else return false;    
+}
+
 export {
     groupList, 
+    limitGroupNum,
+    limitTiccleNum,
     getAllGroupIncludeImages,
     doCreateGroup, 
     doUpdateGroup, 
     doDeleteGroup, 
-    checkIsExistingGroup
+    checkIsExistingGroup,
+    getTotalGroupNum,
+    checkIsFullGroupNum,
+    getTotalTiccleNum,
+    checkIsFullTiccleNum,
 };

--- a/src/model/GroupModel.js
+++ b/src/model/GroupModel.js
@@ -1,6 +1,7 @@
 import {
     uploadNewGroup,
-    updateGroupInfo, updateGroupImage,
+    updateGroupInfo, 
+    updateGroupImage,
     deleteGroup,
     findAllGroupIncludeImage } from '../service/GroupService';
 

--- a/src/model/GroupModel.js
+++ b/src/model/GroupModel.js
@@ -80,6 +80,9 @@ async function doUpdateGroup(groupId, newInfo, isIncludingImage, oldImageName, n
     if (imageUrl == '') newInfo = {...oldInfo, ...info}
     else newInfo = {...oldInfo, ...info, imageUrl: imageUrl}
     setGroupListAtOne(groupId, newInfo);
+
+    // for updating imageUrl in screen
+    if (isIncludingImage) return imageUrl;
 }
 
 /**

--- a/src/model/GroupModel.js
+++ b/src/model/GroupModel.js
@@ -26,6 +26,14 @@ async function getAllGroupIncludeImages() {
 }
 
 /**
+ * Get bookmarked group list
+ * @returns {Array} bookmarked group list
+ */
+async function getBookmarkedGroupList() {
+    return groupList.filter(obj => obj.bookmark == true);
+}
+
+/**
  * Upload new group and add to groupList
  * @param {*} groupData: group info
  * *  {
@@ -105,4 +113,12 @@ function checkIsExistingGroup(groupTitle) {
     else return true;
 }
 
-export {groupList, getAllGroupIncludeImages, doCreateGroup, doUpdateGroup, doDeleteGroup, checkIsExistingGroup};
+export {
+    groupList, 
+    getAllGroupIncludeImages, 
+    getBookmarkedGroupList,
+    doCreateGroup, 
+    doUpdateGroup, 
+    doDeleteGroup, 
+    checkIsExistingGroup
+};

--- a/src/model/TiccleModel.js
+++ b/src/model/TiccleModel.js
@@ -7,6 +7,20 @@ import {
     findImagesOfTiccle,
 } from "../service/TiccleService";
 
+/*
+ * Ticcle data
+    {
+        groupId: group id,
+        title: string,
+        link: string, // URL of original content
+        content: string,
+        tagList: Array<string>,
+        images: Array<string>, // array of image paths in storage
+        imageUrl: Array<string>, // array of image downloadUrls
+        lastModifiedTime: number
+    }
+*/
+
 var groupId = ''; // ticcle list belongs to
 var ticcleList = [];
 function setNewTiccleList(_groupId, _ticcleList){

--- a/src/navigation/stack/TiccleStackNavigator.js
+++ b/src/navigation/stack/TiccleStackNavigator.js
@@ -12,7 +12,7 @@ const TiccleStack = createStackNavigator();
 
 const TiccleStackNavigator = () => {
 
-    const {ticcle, setTiccleDate} = UseTiccleCreate();
+    const {ticcle} = UseTiccleCreate();
     const [saveButtonDisable, setSaveButtonDisable] = useState(true);
 
 

--- a/src/service/GroupService.js
+++ b/src/service/GroupService.js
@@ -60,13 +60,13 @@ async function uploadNewGroup(group, mainImageSource) {
     }
  */
 function updateGroupInfo(groupId, newInfo) {
-    const updateInfo = {...newInfo, lastModifiedTime: Date.now()};
+    // no update lastModifiedTime
     const ref = userDoc.collection('Group').doc(groupId);
-    ref.update(updateInfo);
+    ref.update(newInfo);
 }
 
 /**
- * Update ticcleNum and lastModifiedTime of Group
+ * Update ticcleNum
  * @param {string} groupId
  * @param {boolean} isPlus: true if +1 else -1
  */
@@ -75,7 +75,7 @@ async function updateTiccleNumOfGroup(groupId, isPlus) {
     const group = await ref.get();
     var num = group.ticcleNum;
     num = isPlus ? num + 1 : num - 1;
-    ref.update({ticcleNum: num, lastModifiedTime: Date.now()});
+    ref.update({ticcleNum: num});
 }
 
 /**

--- a/src/service/GroupService.js
+++ b/src/service/GroupService.js
@@ -40,7 +40,7 @@ async function uploadNewGroup(group, mainImageSource) {
         mainImage: imageName,
         ticcleNum: 0,
         latestTiccleTitle: '',
-        lastModifiedTime: Date.now(),
+        lastModifiedTime: Date.now(), // this treated like 'createdTime' (NOT UPDATE after create)
     });
     return new Promise(resolve => {
         resolve({...result, imageUrl: downloadURL});

--- a/src/service/GroupService.js
+++ b/src/service/GroupService.js
@@ -33,20 +33,17 @@ async function uploadNewGroup(group, mainImageSource) {
     let downloadURL = '';
     if (mainImageSource || mainImageSource != '') {
         imageName = Date.now() + '.jpg';
-        downloadURL = await uploadImageToStorage( imageName, mainImageSource );
-        // uploadImageToStorage(imageName, mainImageSource);
+        downloadURL = await uploadImageToStorage(imageName, mainImageSource);
     }
-    // return createGroup({ ...group, mainImage: imageName, ticcleNum: 0, latestTiccleTitle: '', lastModifiedTime: Date.now() });
+    const result = await createGroup({
+        ...group,
+        mainImage: imageName,
+        ticcleNum: 0,
+        latestTiccleTitle: '',
+        lastModifiedTime: Date.now(),
+    });
     return new Promise(resolve => {
-        const result = createGroup({
-            ...group,
-            mainImage: imageName,
-            ticcleNum: 0,
-            latestTiccleTitle: '',
-            lastModifiedTime: Date.now(),
-            imageUrl: downloadURL,
-        });
-        resolve(result);
+        resolve({...result, imageUrl: downloadURL});
     });
 }
 
@@ -91,18 +88,13 @@ async function updateGroupImage(oldImageName, newImageSource) {
     // delete original image first
     if (oldImageName)
         deleteImageFromStorage(oldImageName, false);
+    
     // upload new image
-    // newImageName = Date.now() + ".jpg";
-    // uploadImageToStorage(newImageName, newImageSource);
-    // // update group info
-    // //updateGroupInfo(groupId, {mainImage: newImageName});
-    // return newImageName;
-    newImageName = Date.now() + '.jpg';
-    const downloadUrl = await uploadImageToStorage(newImageName, newImageSource);
+    const newImageName = Date.now() + '.jpg';
+    const downloadUrl = await uploadImageToStorage(newImageName, newImageSource, false);
+
     // return newImageInfo
     return new Promise(resolve => {
-        console.log('\n\nupdateGroupImage : downloadUrl==============');
-        console.log(downloadUrl);
         resolve([downloadUrl, newImageName]);
     });
 }

--- a/src/service/TiccleService.js
+++ b/src/service/TiccleService.js
@@ -67,7 +67,7 @@ function updateTiccleInfo(groupId, ticcleId, newInfo) {
     const ref = userDoc.collection("Ticcle").doc(ticcleId);
     var updateInfo = {...newInfo, lastModifiedTime: Date.now()};
     ref.update(updateInfo);
-    updateGroupInfo(groupId); // only update lastModifiedDate!
+    //if (newInfo.title) updateGroupInfo(groupId, {latestTiccleTitle: newInfo.title}) // 최근 title 에는 수정된 것도 포함인지?
 }
 
 /**


### PR DESCRIPTION
## 개요
- 기존에 그룹 생성 시 홈 화면에 바로 반영되지 않는 이슈를 중심으로 기타 오류 수정 및 수정 사항을 반영했습니다.

## 상세내용
- `lastModifiedTime` 을 Service 단에서 넣어주면서 불필요한 screen 쪽 `lastModifiedTime` 삭제
- @bella0413 님이 `imageUrl` 이 반환되지 않아 홈 화면에 바로 보이지 않는 문제를 발견해주셔서, `imageUrl` 을 포함한 배열을 반환하도록 group create 랑 update 쪽 부분을 수정했습니다. (수정해주신 `imageUrl` 을 group data 에 올리는 방식은 해당 PR 에 comment 남긴대로 삭제하고 반환하는 쪽으로 수정했습니다.)
- bookmark list 에 이미지가 안보이는 이슈는, 수정 전에 어떤 형태였는지 확인은 못했으나 중간 과정에서 정보가 빠지거나 update 할 때 기존 정보를 없앤 것으로 보입니다. 둘 중 무엇이 원인이었듯, 제대로 작동하도록 수정하였습니다!
- 기존에는 group update 후 GroupDetail 로 가면 imageUrl 이 아니라 imageSource 를 사용하였는데, 그냥 두기로 했다가 말씀하신 "유저가 혹시라도 이미지를 삭제했을 경우도 있으니" 가 걸려서 imageUrl 을 사용하는 것으로 변경했습니다.
- group/ticcle 에 대한 개수 제한을 `GroupModel` 에 체크할 수 있게 두었으니, 별도로 화면에서 20개 이렇게 정의하는 것이 아니라, `GroupModel` 의 `limitGroupNum`, `limitTiccleNum` 을 사용해주세요! (혹시 개수가 바뀔 때를 대비하여...)

## 리뷰어가 확인할 사항
- 이제 Group 정보에서 `lastModifiedTime` 은 group 을 생성할 "때만" 변경되도록 했습니다. 사유는 더이상 그룹의 최신 수정 사항을 추적할 필요가 없어졌기 때문 (홈 화면에서 그냥 그룹을 처음 생성했을 때의 시간을 기준으로 보여줌) 입니다만 혹시 이 그룹의 `lastModifiedTime` 가 변경되어야 하는 부분이 있어서 이렇게 하면 안되는 경우가 있다면 꼭! 말씀해주세요! (지금의 `lastModifiedTime` 는 그냥 createdTime 이라고 보시면 됩니다)

## 기타
- 잘 작동하는 모습을 녹화했는데 디스코드 채널로 올려둘게요~😋
