### PR TITLE
Fix/handle ticcle

### DIFF
--- a/src/model/TiccleModel.js
+++ b/src/model/TiccleModel.js
@@ -81,19 +81,28 @@ async function doCreateTiccle(ticcleData, images) {
         tagList: Array<String>
     }
  * @param {boolean} isIncludingImage if update image, ture. else false(: no need to consider below parameters)
+ * @param {Array} images images of ticcle
  * @param {Array} oldImageNames array of old image names // (BE DELETED IMAGE ONLY) if no old images, put []
- * @param {Array} newImageSources array of new image sources
+ * @param {Array} newImageSources array of new image sources // if no new images, put []
  * @returns {Array} updated ticcle data (all)
  */
-async function doUpdateTiccle(groupId, ticcleId, newInfo, isIncludingImage, oldImageNames, newImageSources) {
+async function doUpdateTiccle(groupId, ticcleId, newInfo, isIncludingImage, images, oldImageNames, newImageSources) {
     var info = {...newInfo};
 
     // to server
-    if(isIncludingImage) {
+    if (isIncludingImage) {
         // newImagesInfo = {images: images, imageUrl: imageUrl}
         const newImagesInfo = await updateTiccleImage(oldImageNames, newImageSources);
-        updateTiccleInfo(groupId, ticcleId, {...newInfo, images: newImagesInfo.images});
-        info = {...info, ...newImagesInfo}; // including imageUrls of new images
+
+        const newImages = [...images];
+        oldImageNames.forEach((name) => {
+            const idx = newImages.findIndex(imageName => imageName === name);
+            if (idx >= 0) newImages.splice(idx, 1);
+        })
+        newImages = [...newImages, newImagesInfo.images];
+
+        updateTiccleInfo(groupId, ticcleId, {...newInfo, images: newImages});
+        info = {...info, images: newImages, imageUrl: newImagesInfo.imageUrl}; // including imageUrls of new images
     }
     else updateTiccleInfo(groupId, ticcleId, newInfo);
 

--- a/src/model/TiccleModel.js
+++ b/src/model/TiccleModel.js
@@ -64,6 +64,7 @@ async function doCreateTiccle(ticcleData, images) {
 
     // to local data
     ticcleList = [...ticcleList, newTiccleInfo];
+    return newTiccleInfo;
 }
 
 /**
@@ -97,6 +98,7 @@ function doUpdateTiccle(groupId, ticcleId, newInfo, isIncludingImage, images, ol
     // to local data
     const oldInfo = ticcleList.find(t => t.id == ticcleId)
     setTiccleListAtOne(ticcleId, {...oldInfo, ...info})
+    return {...oldInfo, ...info};
 }
 
 /**

--- a/src/model/TiccleModel.js
+++ b/src/model/TiccleModel.js
@@ -57,6 +57,7 @@ async function getTiccleListByGId(groupId) {
         tagList: Array<String>
     }
  * @param {Array} images: image source array - LIMIT 2
+ * @returns {Array} new ticcle data (info)    
  */
 async function doCreateTiccle(ticcleData, images) {
     // to server
@@ -71,7 +72,7 @@ async function doCreateTiccle(ticcleData, images) {
  * Update ticcle data and add to ticcleList
  * @param {string} groupId: original group id ticcle belong to
  * @param {string} ticcleId
- * @param {Array} newInfo: new ticcle info (CHANGED INFO ONLY) (NO IMAGES)
+ * @param {Array} newInfo: new ticcle info (CHANGED INFO ONLY) (don't put images info here)
  * Support info:
  * *  {
         title: String,
@@ -80,20 +81,21 @@ async function doCreateTiccle(ticcleData, images) {
         tagList: Array<String>
     }
  * @param {boolean} isIncludingImage if update image, ture. else false(: no need to consider below parameters)
- * @param {Array} images old images array // if not exists, put []
- * @param {string} oldImageName old image name // if not exists, put null
- * @param {*} newImageSource new image source
- * @returns {Array} newImageName array
+ * @param {Array} oldImageNames array of old image names // (BE DELETED IMAGE ONLY) if no old images, put []
+ * @param {Array} newImageSources array of new image sources
+ * @returns {Array} updated ticcle data (all)
  */
-function doUpdateTiccle(groupId, ticcleId, newInfo, isIncludingImage, images, oldImageName, newImageSource) {
+async function doUpdateTiccle(groupId, ticcleId, newInfo, isIncludingImage, oldImageNames, newImageSources) {
     var info = {...newInfo};
 
     // to server
     if(isIncludingImage) {
-        const newImages = updateTiccleImage(images, oldImageName, newImageSource);
-        info = {...info, images: newImages};
+        // newImagesInfo = {images: images, imageUrl: imageUrl}
+        const newImagesInfo = await updateTiccleImage(oldImageNames, newImageSources);
+        updateTiccleInfo(groupId, ticcleId, {...newInfo, images: newImagesInfo.images});
+        info = {...info, ...newImagesInfo}; // including imageUrls of new images
     }
-    updateTiccleInfo(groupId, ticcleId, info);
+    else updateTiccleInfo(groupId, ticcleId, newInfo);
 
     // to local data
     const oldInfo = ticcleList.find(t => t.id == ticcleId)

--- a/src/service/TiccleService.js
+++ b/src/service/TiccleService.js
@@ -8,12 +8,14 @@ const userDoc = firestore().collection('RTiccle').doc(user.uid);
 
 /**
  * @param {*} newTiccle
- * @returns {Array} Ticcle Data
+ * @returns {Promise} Ticcle Data
  */
 async function createTiccle(newTiccle) {
     const ref = userDoc.collection("Ticcle"); // using auto id
     const ticcleRef = await ref.add(newTiccle);
-    return { id: ticcleRef.id, ...newTiccle };
+    return new Promise (resolve => {
+        resolve( { id: ticcleRef.id, ...newTiccle });
+    });
 }
 
 /**

--- a/src/service/TiccleService.js
+++ b/src/service/TiccleService.js
@@ -75,7 +75,7 @@ function updateTiccleInfo(groupId, ticcleId, newInfo) {
 /**
  * Update ticcle images
  * @param {Array} oldImageNames array of old image names // (BE DELETED IMAGE ONLY) if no old images, put []
- * @param {Array} newImageSources array of new image sources
+ * @param {Array} newImageSources array of new image sources // if no new images, put []
  * @returns {Array} list of images, imageUrl (- {images: images, imageUrl: imageUrl})
  */
 async function updateTiccleImage(oldImageNames, newImageSources) {

--- a/src/service/TiccleService.js
+++ b/src/service/TiccleService.js
@@ -69,31 +69,32 @@ function updateTiccleInfo(groupId, ticcleId, newInfo) {
     const ref = userDoc.collection("Ticcle").doc(ticcleId);
     var updateInfo = {...newInfo, lastModifiedTime: Date.now()};
     ref.update(updateInfo);
-    //if (newInfo.title) updateGroupInfo(groupId, {latestTiccleTitle: newInfo.title}) // 최근 title 에는 수정된 것도 포함인지?
+    if (newInfo.title) updateGroupInfo(groupId, {latestTiccleTitle: newInfo.title}) // 최근 title 은 업데이트순
 }
 
 /**
  * Update ticcle images
- * @param {Array} images old images array // if not exists, put []
- * @param {string} oldImageName old image name // if not exists, put null
- * @param {*} newImageSource new image source
- * @returns {Array} newImageName array
+ * @param {Array} oldImageNames array of old image names // (BE DELETED IMAGE ONLY) if no old images, put []
+ * @param {Array} newImageSources array of new image sources
+ * @returns {Array} list of images, imageUrl (- {images: images, imageUrl: imageUrl})
  */
-function updateTiccleImage(images, oldImageName, newImageSource) {
-    var newImages = [...images];
-    // delete original image first
-    if (oldImageName) {
-        deleteImageFromStorage(oldImageName, true);
-        let idx = newImages.indexOf(oldImageName);
-        newImages.splice(idx, 1);
+async function updateTiccleImage(oldImageNames, newImageSources) {
+    // delete old images first
+    oldImageNames.forEach((imageName) => {
+        deleteImageFromStorage(imageName, true);
+    })
+    // upload new images
+    var images = [];
+    var imageUrl = [];
+    for (let imageSource of newImageSources) {
+        const newImageName = Date.now() + ".jpg";
+        const downloadUrl = await uploadImageToStorage(newImageName, imageSource);
+        images.push(newImageName);
+        imageUrl.push(downloadUrl)
     }
-    // upload new image
-    newImageName = Date.now() + ".jpg";
-    uploadImageToStorage(newImageName, newImageSource);
-    newImages.push(newImageName);
-    // update group info
-    //updateTiccleInfo(groupId, ticcleId, {images: newImages});
-    return newImages;
+    return new Promise(resolve => {
+        resolve({images: images, imageUrl: imageUrl});
+    });
 }
 
 /**


### PR DESCRIPTION
## 개요
- Ticcle 에 대해 수정사항 반영

## 상세내용
- Ticcle create/update 후 Ticcle 정보를 반환하도록 수정
- Ticcle images 를 업데이트하는 방법 수정
  - `oldImageNames` 는 삭제할 이미지 이름에 대한 Array, `newImageSources` 는 새로 올릴 이미지 source 에 대한 Array
  - 삭제할 이미지, 즉 `oldImageNames` 가 없는 경우 `[]` 를 넣어주세요.
  - 화면 쪽에서 삭제하거나 새로 올릴 부분을 알아서 골라줘야 하며, 이미지가 최대 2개인 것도 고려해주셔야 합니다.

## 리뷰어가 확인할 사항
- Ticcle images 를 업데이트 하는 방법에 더 좋은 방법이 있다면, 또는 로직이 잘못된 경우가 있다면 알려주세요.

## 기타
