### PR TITLE
User Privacy: get privacy policy and reset user data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2521,6 +2521,11 @@
       "resolved": "https://registry.npmjs.org/@react-native-firebase/firestore/-/firestore-13.0.1.tgz",
       "integrity": "sha512-kOkoQvdYU5W9iAZX9SAN7aoNvZpZZ3CywzoQer0uHp2gFwm02TCeOeEGOVhsbuh+D4uRdD3k5My/zV97OWTlFw=="
     },
+    "@react-native-firebase/functions": {
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/@react-native-firebase/functions/-/functions-14.3.0.tgz",
+      "integrity": "sha512-bGKe+kuZhITapUgDw8ihWjuQ2a1JPQanofBG38VbHRK5BZ1DjKwTAuXJPLRHLKM+BQ+b//ga39GjvhLHOWBC2g=="
+    },
     "@react-native-firebase/storage": {
       "version": "13.0.1",
       "resolved": "https://registry.npmjs.org/@react-native-firebase/storage/-/storage-13.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@react-native-firebase/app": "13.0.1",
     "@react-native-firebase/auth": "13.0.1",
     "@react-native-firebase/firestore": "13.0.1",
+    "@react-native-firebase/functions": "14.3.0",
     "@react-native-firebase/storage": "13.0.1",
     "@react-native-google-signin/google-signin": "7.0.1",
     "@react-navigation/bottom-tabs": "6.0.9",

--- a/src/service/AuthService.js
+++ b/src/service/AuthService.js
@@ -1,5 +1,6 @@
 import auth from "@react-native-firebase/auth";
 import firestore from '@react-native-firebase/firestore';
+import { firebase } from '@react-native-firebase/functions';
 import { GoogleSignin } from "@react-native-google-signin/google-signin";
 
 var currentUser = getCurrentUser();
@@ -64,6 +65,14 @@ function logout () {
     return auth().signOut();
 }
 
+function resetUserData(uid) {
+    const functions = firebase.app().functions('asia-northeast2');
+    functions.httpsCallable('clearDataOnCall')({uid: uid})
+        .then((res) => {
+          console.log(res);
+        })
+}
+
 function getUserProfile(setState) {
   const user = auth().currentUser;
   if (user !== null) {
@@ -87,4 +96,5 @@ export {
   getCurrentUser,
   getUserProfile,
   logout,
+  resetUserData,
 };

--- a/src/service/CommonService.js
+++ b/src/service/CommonService.js
@@ -1,3 +1,5 @@
+import firestore from '@react-native-firebase/firestore';
+
 /* deprecated */
 /**
  * Return firebase firestore timestamp of now
@@ -21,6 +23,19 @@ function timeStampToFormatDate(timeStamp) {
     return formattedday;
 }
 
+/**
+ * Get privacy policy of RTiccle from firestore
+ * @returns {Promise<String>} privacy policy
+ */
+async function getPrivacyPolicy() {
+    const doc = await firestore().collection('Info').doc('Privacy').get();
+    const policy = doc.data().policy;
+    return new Promise(resolve => {
+        resolve(policy);
+    });
+}
+
 export {
     timeStampToFormatDate,
+    getPrivacyPolicy,
 }

--- a/src/service/CommonService.js
+++ b/src/service/CommonService.js
@@ -1,14 +1,5 @@
 import firestore from '@react-native-firebase/firestore';
 
-/* deprecated */
-/**
- * Return firebase firestore timestamp of now
- * @returns {FirebaseFirestoreTypes.Timestamp}
- */
-function FBDate() {
-    return firestore.Timestamp.fromDate(new Date());
-}
-
 /**
  * Convert firebase firestore timestamp to YY.MM.DD format date
  * @param {number} timeStamp

--- a/src/service/GroupService.js
+++ b/src/service/GroupService.js
@@ -134,7 +134,7 @@ async function findAllGroup(setState) {
  * @returns {Promise<Array>} Group List (include image url)
  */
 async function findAllGroupIncludeImage() {
-    const querySnapshot = await userDoc.collection('Group')
+    const querySnapshot = await collection.doc(currentUser.uid).collection('Group')
         .orderBy('lastModifiedTime', 'desc')
         .get();
     var snapshots = [];

--- a/src/service/GroupService.js
+++ b/src/service/GroupService.js
@@ -113,22 +113,6 @@ function deleteGroup(group) {
     ref.delete();
 }
 
-/* deprecated */
-/**
- * Get All Group of User and Set state
- * @param {Dispatch<SetStateAction<S>>} setState
- */
-async function findAllGroup(setState) {
-    const querySnapshot = await collection.doc(currentUser.uid).collection('Group').get();
-    var groups = [];
-    querySnapshot.forEach(snapshot => {
-        const id = snapshot.id;
-        const group = {...snapshot.data(), id};
-        groups = [...groups, group];
-    });
-    setState(groups);
-}
-
 /**
  * Get All Group of User (include main image url)
  * @returns {Promise<Array>} Group List (include image url)
@@ -155,115 +139,19 @@ async function findAllGroupIncludeImage() {
     });
 }
 
-/* deprecated */
 /**
- * Find groups include main image url with limiting and Set state
- * @param {*} limit: maximum number of groups
- * @param {Dispatch<SetStateAction<S>>} setState
- * @returns {Array} Group List (include image url)
- */
-async function findGroupsIncludeImage(limit, setState) {
-    const query = collection.doc(currentUser.uid).collection('Group').orderBy('lastModifiedTime', 'desc').limit(limit);
-    const querySnapshot = await query.get();
-    var snapshots = [];
-    querySnapshot.forEach(snapshot => snapshots.push({id: snapshot.id, data: snapshot.data()}));
-    var groups = [];
-    for (let group of snapshots) {
-        const id = group.id;
-        var data = group.data;
-        var mainImageURL = null;
-        if (data.mainImage || data.mainImage != '') { // get download URL
-            mainImageURL = await getDownloadURLByName(data.mainImage, false);
-        }
-        data = {...data, imageUrl: mainImageURL, id: id};
-        groups = [...groups, data];
-    }
-    setState(groups);
-}
-
-/* deprecated */
-/**
- * Find bookmark groups include main image url with limiting and Set state
- * @param {Dispatch<SetStateAction<S>>} setState
- * @returns {Array} Group List (include image url)
- */
-async function findBookrmarkGroupsIncludeImage(setState) {
-    const query = collection.doc(currentUser.uid).collection('Group').where('bookmark', '==', true);
-
-    const querySnapshot = await query.get();
-    var snapshots = [];
-    querySnapshot.forEach(snapshot => snapshots.push({id: snapshot.id, data: snapshot.data()}));
-    var groups = [];
-    for (let group of snapshots) {
-        const id = group.id;
-        var data = group.data;
-        var mainImageURL = null;
-        if (data.mainImage || data.mainImage != '') { // get download URL
-            mainImageURL = await getDownloadURLByName(data.mainImage, false);
-        }
-        data = {...data, imageUrl: mainImageURL, id: id};
-        groups = [...groups, data];
-    }
-    setState(groups);
-}
-
-/* deprecated */
-/**
- * check whether a group name exists or not
- * @param {string} groupTitle
- * @returns {Boolean} true is existing group
- */
-async function checkIsExistingGroup(groupTitle) {
-    const querySnapshot = await collection.doc(currentUser.uid).collection('Group').get();
-    var found = false;
-    querySnapshot.forEach(snapshot => {
-        if (snapshot.title == groupTitle) found = true;
-    });
-    return found;
-}
-
-/* deprecated */
-/**
- * Get One Group By Id (DocumentSnapshot.id) and Set state
- * @param {*} groupId
- * @param {Dispatch<SetStateAction<S>>} setState
- * @returns {DocumentSnapshot} (of Group doc) if exist, else null
- */
-async function findGroupById(groupId, setState) {
-    const group = await collection.doc(currentUser.uid).collection('Group').doc(groupId).get();
-    if (group.exists) setState(group.data());
-    else setState([]);
-}
-
-/* deprecated */
-/**
- * Get group data include image by groupId
+ * Get one group by group id
  * @param {string} groupId
- * @returns {Array} Group data (include image url)
+ * @returns {Promise<Array>} group data if exist, else null
  */
-async function findGroupByIdIncludeImage(groupId, setState) {
-    const group = await collection.doc(currentUser.uid).collection('Group').doc(groupId).get();
-    let data = group.data();
-    var mainImageURL = null;
-    if (data.mainImage || data.mainImage != '') { // get download URL
-        mainImageURL = await getDownloadURLByName(data.mainImage, false);
+async function findGroupById(groupId) {
+    const doc = await collection.doc(currentUser.uid).collection('Group').doc(groupId).get();
+    if (doc.exists) {
+        return new Promise(resolve => {
+            resolve({...doc.data(), id: doc.id});
+        });
     }
-    data = {...data, imageUrl: mainImageURL};
-    setState(data);
-}
-
-/* deprecated */
-/**
- * Check whether more than one group exists or not
- * @returns {boolean} true: existed, false: not existed
- */
-async function checkIsExistingAnyGroup() {
-    const querySnapshot = await collection.doc(currentUser.uid).collection('Group').get();
-    if (querySnapshot.size === 0) {
-        return false;
-    } else {
-        return true;
-    }
+    else return null;
 }
 
 export {
@@ -274,5 +162,5 @@ export {
     updateGroupImage,
     deleteGroup,
     findAllGroupIncludeImage,
-    findGroupByIdIncludeImage,
+    findGroupById,
 };

--- a/src/service/SearchService.js
+++ b/src/service/SearchService.js
@@ -7,7 +7,7 @@ const userFilter = `uid:${currentUser.uid}`
 
 async function initAlgolia() {
     // Get Algolia keys first
-    const doc = await firestore().collection('Algolia').doc('algolia').get();
+    const doc = await firestore().collection('Info').doc('Algolia').get();
     const algolia = doc.data();
 
     // Generate Algolia client and target index

--- a/src/service/TiccleService.js
+++ b/src/service/TiccleService.js
@@ -118,7 +118,7 @@ function deleteTiccle(ticcle) {
  * @returns {Promise<Array>} Ticcle List
  */
 async function findTiccleListByGroupId(groupId) {
-    const querySnapshot = await userDoc.collection("Ticcle")
+    const querySnapshot = await collection.doc(currentUser.uid).collection("Ticcle")
         .where("groupId", "==", groupId)
         .orderBy('lastModifiedTime', 'desc')
         .get();

--- a/src/service/TiccleService.js
+++ b/src/service/TiccleService.js
@@ -134,15 +134,18 @@ async function findTiccleListByGroupId(groupId) {
     });
 }
 
-/* deprecated */
 /**
- * Get One Ticcle By Id (DocumentSnapshot.id)
- * @param {*} ticcleId 
- * @returns {Array} (of Ticcle doc) if exist, else null
+ * Get one ticcle by ticcle id
+ * @param {string} ticcleId 
+ * @returns {Promise<Array>} ticcle data if exist, else null
  */
 async function findTiccleById(ticcleId) {
-    const ticcle = await collection.doc(currentUser.uid).collection("Ticcle").doc(ticcleId).get()
-    if (ticcle.exists) return ticcle.data();
+    const doc = await collection.doc(currentUser.uid).collection("Ticcle").doc(ticcleId).get();
+    if (doc.exists) {
+        return new Promise(resolve => {
+            resolve({...doc.data(), id: doc.id});
+        });
+    }
     else return null;
 }
 


### PR DESCRIPTION
## 개요
- 개인정보처리방침 불러오는거랑 사용자 데이터 초기화 부분 구현했습니다.

## 상세내용
- 개인정보처리방침을 firestore 에 저장해두고 불러옵니다. (`getPrivacyPolicy`)
- 사용자 데이터 초기화 (`resetUserData`)
- deprecated 로 명시해둔, 필요 없고 사용하지도 않는 함수들 다 지웠습니다.

## 리뷰어가 확인할 사항
- @react-native-firebase/functions 이 추가됐습니다. 확인 후 실행해주세요.

## 기타
