### PR TITLE
Fix: on delete latest-ticcle and user data

### DIFF
--- a/src/containers/common/SearchBar.js
+++ b/src/containers/common/SearchBar.js
@@ -40,9 +40,9 @@ const SearchBar = ({ isSearchScreen, placeholderContext, setPressSearchBtn, pres
                 .then((res) => {
                     let sortResult = isLatestSort ? sortDescByLMT(res) : sortAscByLMT(res);
                     setSearchResult(sortResult);
+                    setIsLoading(false);
                 })
                 .catch(err => handleError(err))
-                setIsLoading(false);
         } else {
             const result = searchTiccleByTitltAndTagInGroup(ticcleList, query, tagQuery);
             let sortResult = isLatestSort ? sortDescByLMT(result) : sortAscByLMT(result);

--- a/src/containers/ticcle/detail/components/TiccleDetailFloatingButton.js
+++ b/src/containers/ticcle/detail/components/TiccleDetailFloatingButton.js
@@ -14,9 +14,9 @@ const TiccleDetailFloatingButton = ({ticcleData}) => {
     const handleError = useErrorHandler(); // for error handling
 
     const [deleteModalVisible, setDeleteModalVisible] = useState(false);
-    const deleteModalEvent = () => {
+    const deleteModalEvent = async () => {
         try {
-            doDeleteTiccle( ticcleData );
+            await doDeleteTiccle( ticcleData );
             setIsTiccleListChanged( !isTiccleListChanged );
             setIsGroupChanged( !isGroupChanged );
             navigation.navigate( 'HomeStack' );

--- a/src/containers/user/MyPage.js
+++ b/src/containers/user/MyPage.js
@@ -14,10 +14,6 @@ const MyPage = () => {
         name: '',
         email: '',
     })
-    // Error handling example
-    // const Bomb = () => {
-    //     throw new Error('MyPage rendering error')
-    // }
 
     useEffect(() => {
         if (currentUser != null) setIsGuest(currentUser.isAnonymous);

--- a/src/containers/user/components/Settings.js
+++ b/src/containers/user/components/Settings.js
@@ -5,19 +5,27 @@ import { logout, resetUserData, currentUser } from '../../../service/AuthService
 import CustomModal from '../../common/CustomModal';
 import PrivacyModal from './PrivacyModal';
 import { restartApp } from '../../../service/CommonService';
+import {useErrorHandler} from 'react-error-boundary';
+import Spinner from '../../common/Spinner';
 
 const Setting = ({isGuest, setIsGuest}) => {
-
     const [dataResetModal, setDataResetModal] = useState(false);
     const [privacyModalVisible, setPrivacyModalVisible] = useState(false);
+    const [isLoading, setIsLoading] = useState(false);
+    const handleError = useErrorHandler(); // for error handling
+    
     const logoutButtonEvent = () => {
         logout();
         setIsGuest(true);
         restartApp();
     }
     const resetButtonEvent = () => {
-        resetUserData(currentUser.uid)
-        restartApp();
+        setDataResetModal(false);
+        setIsLoading(true);
+        resetUserData(currentUser.uid).then(() => {
+            setIsLoading(false);
+            restartApp();
+        }).catch(err => handleError(err));
     }
     const PrivacyModalVisibleTrue = () => {
         setPrivacyModalVisible(true)
@@ -35,6 +43,7 @@ const Setting = ({isGuest, setIsGuest}) => {
                 rightButtonFunction={resetButtonEvent}
                 warning={true}
             />
+            {isLoading && <Spinner></Spinner>}
             <View style={styles.container}>
                 {isGuest ? null :
                 <SettingItem

--- a/src/model/TiccleModel.js
+++ b/src/model/TiccleModel.js
@@ -129,14 +129,19 @@ async function doUpdateTiccle(groupId, ticcleId, newInfo, isIncludingImage, imag
 /**
  * Delete one ticcle add apply to ticcleList
  * @param {Array} ticcleData 
+ * @returns {Promise<string>} newLatestTiccleTitle if changed, else null
  */
-function doDeleteTiccle(ticcleData) {
+async function doDeleteTiccle(ticcleData) {
     // to server
-    deleteTiccle(ticcleData);
+    const newLatestTiccleTitle = await deleteTiccle(ticcleData);
 
     // to local data
     deleteOneTiccleOfList(ticcleData.id);
-    updateGroupInfoOfList(ticcleData.groupId, null, true, false); // update ticcleNum at local group data
+    updateGroupInfoOfList(ticcleData.groupId, newLatestTiccleTitle, true, false); // update ticcleNum at local group data
+
+    return new Promise(resolve => {
+        resolve(newLatestTiccleTitle);
+    });
 }
 
 /**

--- a/src/service/AuthService.js
+++ b/src/service/AuthService.js
@@ -65,12 +65,9 @@ function logout () {
     return auth().signOut();
 }
 
-function resetUserData(uid) {
+async function resetUserData(uid) {
     const functions = firebase.app().functions('asia-northeast2');
-    functions.httpsCallable('clearDataOnCall')({uid: uid})
-        .then((res) => {
-          console.log(res);
-        })
+    return await functions.httpsCallable('clearDataOnCall')({uid: uid});
 }
 
 function getUserProfile(setState) {


### PR DESCRIPTION
## 개요
- 가장 최신 티끌을 삭제할 경우와 사용자 데이터 초기화 시에 기능을 수정했습니다.

## 상세내용
- 가장 최신 티끌을 삭제할 때, 그룹 정보의 `latestTiccleTitle` 을 다음으로 최신인 티끌의 `title` 로 변경합니다. 만일 가장 최신 티끌이자 그 그룹의 유일한 티끌이었다면 (= 더이상 해당 그룹에 티끌이 없는 경우) 빈 문자열('') 로 변경합니다.
- 사용자가 '데이터 초기화'를 할 때, 데이터 초기화가 완료된 후에 앱 재시작을 하도록 변경했습니다. 그리고 초기화하는 동안 초기화 안내 모달을 없애고, Spinner 를 보여줍니다.

## 리뷰어가 확인할 사항

## 기타
