### PR TITLE
fix(auth): delete user when an anonymous user resets data

### DIFF
--- a/src/containers/user/components/Settings.js
+++ b/src/containers/user/components/Settings.js
@@ -26,7 +26,8 @@ const Setting = ({isGuest, setIsGuest}) => {
     const resetButtonEvent = () => {
         setDataResetModal(false);
         setIsLoading(true);
-        resetUserData().then(() => {
+        let promise = isGuest ? unregister() : resetUserData()
+        promise.then(() => {
             setIsLoading(false);
             restartApp();
         }).catch(err => handleError(err));


### PR DESCRIPTION
## 개요
- 게스트 모드에서의 데이터 초기화 방식 수정

## 상세내용
게스트 모드에서 데이터 초기화하면 게스트 아이디를 삭제하는 것으로 변경했습니다.
기존엔 어떤 사용자든 데이터 초기화만 했는데, 게스트 모드의 경우 '로그아웃'이 없어서 관련해서 이슈들이 생겼습니다.
따라서 '데이터 초기화' 시,
- 게스트 모드에서는 게스트 아이디 삭제 (자동으로 데이터 또한 초기화됨) 후 로그인 페이지로 이동
- 구글 사용자 모드에서는 단순 데이터 초기화

로 동작하도록 했습니다.

## 리뷰어가 확인할 사항

## 기타
